### PR TITLE
WSL 関連のスクリプトを更新

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -56,6 +56,17 @@ alias hm='home-manager'
 alias hmsw='home-manager switch -f ~/dotfiles/.config/nixpkgs/home.nix'
 alias sampler='sampler -c ~/.config/sampler/config.yml'
 
+# WSL
+if type wslsys >/dev/null 2>&1; then
+	alias explorer.exe='/mnt/c/Windows/explorer.exe'
+	alias bash.exe='/mnt/c/Windows/system32/bash.exe'
+	alias cmd.exe='/mnt/c/Windows/system32/cmd.exe'
+	alias tasklist.exe='/mnt/c/Windows/system32/tasklist.exe'
+	alias wsl.exe='/mnt/c/Windows/system32/wsl.exe'
+	alias powershell.exe='/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+	alias code='/mnt/c/Users/nokaz/AppData/Local/Programs/Microsoft\ VS\ Code/bin/code'
+fi
+
 # docker ----------------------------------------------------------------------------------------------------
 
 # Run nginx in Docker.

--- a/.path.sh
+++ b/.path.sh
@@ -6,6 +6,14 @@ function is_unregistered_path() {
     ! (echo "$PATH" | grep -q "$1")
 }
 
+function regester_forward_if_not() {
+    is_unregistered_path "$1" && PATH="$1:${PATH}"
+}
+
+function regester_backward_if_not() {
+    is_unregistered_path "$1" && PATH="${PATH}:$1"
+}
+
 # ----------------------------------------------------------------------------------------------------
 
 # set PATH so it includes user's private bin if it exists
@@ -28,12 +36,8 @@ if [[ -d "$HOME/.anyenv" ]]; then
         fi
     fi
     for file in  ~/.anyenv/envs/*; do
-        if is_unregistered_path "$HOME/.anyenv/envs/$(basename "${file}")/bin"; then
-            PATH="$HOME/.anyenv/envs/$(basename "${file}")/bin:$PATH"
-        fi
-        if is_unregistered_path "$HOME/.anyenv/envs/$(basename "${file}")/shims"; then
-            PATH="$HOME/.anyenv/envs/$(basename "${file}")/shims:$PATH"
-        fi
+        regester_forward_if_not "$HOME/.anyenv/envs/$(basename "${file}")/bin"
+        regester_forward_if_not "$HOME/.anyenv/envs/$(basename "${file}")/shims"
     done
 fi
 
@@ -52,9 +56,7 @@ fi
 
 # Nim (choosenim)
 if [[ -d "$HOME/.nimble/bin" ]]; then
-    if is_unregistered_path "$HOME/.nimble"; then
-        PATH="$HOME/.nimble/bin:$PATH"
-    fi
+    regester_forward_if_not "$HOME/.nimble/bin:$PATH"
 fi
 
 # TODO

--- a/.shrc.sh
+++ b/.shrc.sh
@@ -19,30 +19,16 @@ else
     echo "⚠ .path.sh doesn't exist"
 fi
 
-# ---------------------------------------- cdhist  ----------------------------------------
-
-if [[ -f "$HOME/dotfiles/scripts/cdhist.sh" ]]; then
-    . "$HOME/dotfiles/scripts/cdhist.sh"
-fi
-
 # ---------------------------------------- WSL  ----------------------------------------
 
-if type wsl.exe >/dev/null 2>&1; then
+if type wslsys >/dev/null 2>&1; then
     # WSL 内では X Server (VcXsrv) 経由で GUI を表示
     if [[ -f "$HOME/dotfiles/scripts/start_vcxsrv.sh" ]]; then
         # WSL に割り当てられる IP アドレスを取得して設定
         DISPLAY="$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0.0"
         export DISPLAY
-        $HOME/dotfiles/scripts/start_vcxsrv.sh
+        "$HOME/dotfiles/scripts/start_vcxsrv.sh"
     else
         echo "⚠ file 'start_vcxsrv.sh' doesn't exist at ${START_VCXSRV_PATH}" >&2
     fi
-
-    # TODO: ブラウザのランチャー
-    # if type "wslview" >/dev/null 2>&1; then
-    #     BROWSER="wslview"
-    #     export BROWSER
-    # else
-    #     echo "⚠ wslview doesn't exist" >&2
-    # fi
 fi

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ _restore: # Restore backed-up files of dotfiles.
 	$(SCRIPTS_DIR)/_restore/unix.sh
 
 .PHONY: _restore-windows
-_restore: # Restore backed-up files of dotfiles in Windows.
+_restore-windows: # Restore backed-up files of dotfiles in Windows.
 	$(SCRIPTS_DIR)/_restore/windows.sh
 
 # ------------------------------ utilities ------------------------------

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,11 @@ update-go: install-go; # Update Go packages.
 
 .PHONY: _deploy
 _deploy: # Make symbolic links to dotfiles & back up original files if exists.
-	$(SCRIPTS_DIR)/_deploy.sh
+	$(SCRIPTS_DIR)/_deploy/unix.sh
+
+.PHONY: _deploy-windows
+_deploy-windows: # Make symbolic links to dotfiles & back up original files if exists in Windows.
+	$(SCRIPTS_DIR)/_deploy/windows.sh
 
 .PHONY: _restore
 _restore: # Restore backed-up files of dotfiles.

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,11 @@ _deploy: # Make symbolic links to dotfiles & back up original files if exists.
 
 .PHONY: _restore
 _restore: # Restore backed-up files of dotfiles.
-	$(SCRIPTS_DIR)/_restore.sh
+	$(SCRIPTS_DIR)/_restore/unix.sh
+
+.PHONY: _restore-windows
+_restore: # Restore backed-up files of dotfiles in Windows.
+	$(SCRIPTS_DIR)/_restore/windows.sh
 
 # ------------------------------ utilities ------------------------------
 

--- a/scripts/_deploy/main.sh
+++ b/scripts/_deploy/main.sh
@@ -247,7 +247,7 @@ function main() {
     fi
   fi
 
-  deploy "$1" "$2" $3
+  deploy "$1" "$2" "$3"
   if [[ $file_counter -gt 0 ]]; then
     echo "Successfully ${file_counter} dotfiles are initialized!"
   fi

--- a/scripts/_deploy/main.sh
+++ b/scripts/_deploy/main.sh
@@ -2,20 +2,9 @@
 
 set -eu -o pipefail
 
-BASE_DIR=$(cd "$(dirname "$0")"/..; pwd)
-readonly BASE_DIR
 DEBUG=$([[ $# -gt 0 ]] && test "$1" = --debug; echo $?)
 readonly DEBUG
-readonly _BACKUP_DIR_NAME="backup_dotfiles"
 file_counter=0
-
-readonly DESTINATION_BASE_DIR=~
-readonly BACKUP_BASE_DIR=~/${_BACKUP_DIR_NAME}
-
-# 一度 Windows 内のディレクトリに移動して %USERPROFILE% を出力してからもといたディレクトリに戻る
-DESTINATION_BASE_DIR_FOR_WINDOWS=$(cd /mnt/c; wslpath -u "$(cmd.exe /c "echo %USERPROFILE%" | tr -d "\r")"; cd "$OLDPWD")
-readonly DESTINATION_BASE_DIR_FOR_WINDOWS
-readonly BACKUP_BASE_DIR_FOR_WINDOWS="${DESTINATION_BASE_DIR_FOR_WINDOWS}/${_BACKUP_DIR_NAME}"
 
 # ---------------------------------------- utils ----------------------------------------
 
@@ -163,7 +152,7 @@ function newly_link() {
     return 0;
   fi
 
-  WINDOWS_PATH="/mnt/c"
+  local -r WINDOWS_PATH="/mnt/c"
   if [[ $2 =~ ${WINDOWS_PATH} ]]; then
     # TODO: ショートカット作成事態はできるが、.lnk ファイルとして扱われ別物になる
     # local -r source_win="$(wslpath -w $1)"
@@ -196,8 +185,7 @@ function make_symbolic_link() {
     newly_link "$1" "$2"
   elif [[ -f $2 ]] && [[ -f $1 ]]; then
     # ファイルでバックアップがある場合
-    local -r response
-    response=$(show_prompt_for_overwrite "$2")
+    local -r response=$(show_prompt_for_overwrite "$2")
     if [[ ${response} == "y" ]]; then
       make_backup "$2" "$3"
       newly_link "$1" "$2"
@@ -247,7 +235,9 @@ function deploy() {
 
 # ---------------------------------------- main ----------------------------------------
 
-# @param - none
+# @param {string} - source directory path for dotfiles
+# @param {string} - destination directory path
+# @param {stirng} - destination directory for back-up path
 # @return {void}
 function main() {
   if [[ ! ${DEBUG} -eq 0 ]]; then
@@ -257,13 +247,11 @@ function main() {
     fi
   fi
 
-  deploy "${BASE_DIR}" ${DESTINATION_BASE_DIR} ${BACKUP_BASE_DIR}
-  # TODO: option で Windows のファイルを反映するか分けたい
-  deploy "${BASE_DIR}/windows" "${DESTINATION_BASE_DIR_FOR_WINDOWS}" "${BACKUP_BASE_DIR_FOR_WINDOWS}"
+  deploy "$1" "$2" $3
   if [[ $file_counter -gt 0 ]]; then
     echo "Successfully ${file_counter} dotfiles are initialized!"
   fi
 }
 
-main
+main "$1" "$2" "$3"
 exit 0

--- a/scripts/_deploy/unix.sh
+++ b/scripts/_deploy/unix.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+ROOT_DIR=$(cd "$(dirname "${0}")/../../"; pwd)
+readonly ROOT_DIR
+
+function main() {
+  local -r DESTINATION_BASE_DIR=~
+  local -r BACKUP_DIR_NAME='backup_dotfiles'
+
+  "${ROOT_DIR}/scripts/_deploy/main.sh" "${ROOT_DIR}" "${DESTINATION_BASE_DIR}" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" --debug
+}
+
+main

--- a/scripts/_deploy/windows.sh
+++ b/scripts/_deploy/windows.sh
@@ -11,6 +11,7 @@ function main() {
   local -r BACKUP_DIR_NAME='backup_dotfiles'
 
   "${ROOT_DIR}/scripts/_deploy/main.sh" "${ROOT_DIR}"/windows "${DESTINATION_BASE_DIR}" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" --debug
+  sudo cp "${ROOT_DIR}/wsl/etc/wsl.conf" /etc/wsl.conf
 }
 
 main

--- a/scripts/_deploy/windows.sh
+++ b/scripts/_deploy/windows.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+ROOT_DIR=$(cd "$(dirname "${0}")/../../"; pwd)
+readonly ROOT_DIR
+
+function main() {
+  # 一度 Windows 内のディレクトリに移動して %USERPROFILE% を出力する
+  local -r DESTINATION_BASE_DIR="$(cd /mnt/c; wslpath -u "$(/mnt/c/Windows/system32/cmd.exe /c "echo %USERPROFILE%" | tr -d "\r")")"
+  local -r BACKUP_DIR_NAME='backup_dotfiles'
+
+  "${ROOT_DIR}/scripts/_deploy/main.sh" "${ROOT_DIR}"/windows "${DESTINATION_BASE_DIR}" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" --debug
+}
+
+main

--- a/scripts/_restore/main.sh
+++ b/scripts/_restore/main.sh
@@ -2,17 +2,8 @@
 
 set -eu -o pipefail
 
-DEBUG=$([[ $# -gt 0 ]] && test "$1" = --debug; echo $?)
+DEBUG=$([[ $# -gt 3 ]] && test "$3" = --debug; echo $?)
 readonly DEBUG
-readonly _BACKUP_DIR_NAME="backup_dotfiles"
-
-readonly DESTINATION_BASE_DIR=~
-readonly BACKUP_BASE_DIR=~/${_BACKUP_DIR_NAME}
-
-# 一度 Windows 内のディレクトリに移動して %USERPROFILE% を出力してからもといたディレクトリに戻る
-DESTINATION_BASE_DIR_FOR_WINDOWS=$(cd /mnt/c; wslpath -u "$(cmd.exe /c "echo %USERPROFILE%" | tr -d "\r")"; cd "$OLDPWD")
-readonly DESTINATION_BASE_DIR_FOR_WINDOWS
-readonly BACKUP_BASE_DIR_FOR_WINDOWS="${DESTINATION_BASE_DIR_FOR_WINDOWS}/${_BACKUP_DIR_NAME}"
 
 # @param {string} - directory path
 # @return {void}
@@ -93,7 +84,8 @@ function restore() {
 
 # ---------------------------------------- main ----------------------------------------
 
-# @param - none
+# @param {string} - backed-up source directory path
+# @param {string} - destination directory path
 # @return {void}
 function main() {
   if [[ ! ${DEBUG} -eq 0 ]]; then
@@ -103,10 +95,9 @@ function main() {
     fi
   fi
 
-  restore ${BACKUP_BASE_DIR} ${DESTINATION_BASE_DIR}
-  restore "${BACKUP_BASE_DIR_FOR_WINDOWS}" "${DESTINATION_BASE_DIR_FOR_WINDOWS}"
+  restore "$1" "$2"
   return 0
 }
 
-main
+main "$1" "$2"
 exit 0

--- a/scripts/_restore/unix.sh
+++ b/scripts/_restore/unix.sh
@@ -2,14 +2,14 @@
 
 set -eu -o pipefail
 
-BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
-readonly BASE_DIR
+RESTORE_BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
+readonly RESTORE_BASE_DIR
 
 function main() {
   local -r DESTINATION_BASE_DIR=~
   local -r BACKUP_DIR_NAME='backup_dotfiles'
 
-  "${BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
+  "${RESTORE_BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
 }
 
 main

--- a/scripts/_restore/unix.sh
+++ b/scripts/_restore/unix.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
+readonly BASE_DIR
+
+function main() {
+  local -r DESTINATION_BASE_DIR=~
+  local -r BACKUP_DIR_NAME='backup_dotfiles'
+
+  "${BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
+}
+
+main

--- a/scripts/_restore/windows.sh
+++ b/scripts/_restore/windows.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
+readonly BASE_DIR
+
+function main() {
+  # 一度 Windows 内のディレクトリに移動して %USERPROFILE% を出力する
+  local -r DESTINATION_BASE_DIR="$(cd /mnt/c; wslpath -u "$(/mnt/c/Windows/system32/cmd.exe /c "echo %USERPROFILE%" | tr -d "\r")")"
+  local -r BACKUP_DIR_NAME='backup_dotfiles'
+
+  "${BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
+}
+
+main

--- a/scripts/_restore/windows.sh
+++ b/scripts/_restore/windows.sh
@@ -2,15 +2,15 @@
 
 set -eu -o pipefail
 
-BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
-readonly BASE_DIR
+RESTORE_BASE_DIR=$(cd "$(dirname "${0}")"; pwd)
+readonly RESTORE_BASE_DIR
 
 function main() {
   # 一度 Windows 内のディレクトリに移動して %USERPROFILE% を出力する
   local -r DESTINATION_BASE_DIR="$(cd /mnt/c; wslpath -u "$(/mnt/c/Windows/system32/cmd.exe /c "echo %USERPROFILE%" | tr -d "\r")")"
   local -r BACKUP_DIR_NAME='backup_dotfiles'
 
-  "${BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
+  "${RESTORE_BASE_DIR}/main.sh" "${DESTINATION_BASE_DIR}/${BACKUP_DIR_NAME}" "${DESTINATION_BASE_DIR}" --debug
 }
 
 main

--- a/scripts/start_vcxsrv.sh
+++ b/scripts/start_vcxsrv.sh
@@ -4,18 +4,22 @@ set -eu -o pipefail
 
 BASE_DIR=$(cd "$(dirname "${0}")/.."; pwd)
 readonly BASE_DIR
-readonly CONFIG_PATH="${BASE_DIR}/windows/config.xlaunch"
 
 # @param - none
 # @return {void}
 function start_vcxsrv() {
+  local -r CONFIG_PATH="${BASE_DIR}/windows/config.xlaunch"
+  local -r WIN32_PATH=/mnt/c/Windows/system32/
+
   # WSL 内では X Server 経由で GUI を表示
-  if type wsl.exe >/dev/null 2>&1; then
+  if type wslsys >/dev/null 2>&1; then
     # 実行中のプロセス一覧から vcxsrv を抽出した結果が0件で、config_path が存在する場合
-    if (( $(tasklist.exe | grep -c "vcxsrv") == 0 )); then
+    if (( $("${WIN32_PATH}/tasklist.exe" | grep -c "vcxsrv") == 0 )); then
       if [[ -f "${CONFIG_PATH}" ]]; then
         # wsl 内のパスを windows で有効なパスに変換してコマンドプロンプトから xlaunch を実行
-        cd /mnt/c; cmd.exe /c "$(wslpath -w "${CONFIG_PATH}")"; cd "$OLDPWD"
+        cd /mnt/c
+        "${WIN32_PATH}/cmd.exe" /c "$(wslpath -w "${CONFIG_PATH}")"
+        cd "$OLDPWD"
       else
         echo "⚠ file 'config.xlaunch' doesn't exist at ${CONFIG_PATH}" >&2
       fi

--- a/windows/.gitconfig
+++ b/windows/.gitconfig
@@ -5,7 +5,7 @@
 [core]
 	editor = vim
 	repositoryFormatVersion = 0
-	eol = lf
+	eol = crlf
 	autocrlf = input
 	filemode = true
 	bare = false

--- a/wsl/etc/wsl.conf
+++ b/wsl/etc/wsl.conf
@@ -1,0 +1,2 @@
+[interop]
+appendWindowsPath = false


### PR DESCRIPTION
## 概要

- Windows 用の dotfiles を配置・復元するスクリプトを追加
- Windows 用の `.gitconfig` を追加
- Windows の PATH を WSL に追加しないように変更
    - `.exe` ファイルを絶対パス経由で呼ぶよう変更
    - `.exe` ファイルのエイリアスを追加

## 関連

- close #9
- close #13
