### PR TITLE
Vimの起動が遅い問題を解消 & パッケージ管理方法変更

### DIFF
--- a/.config/home-manager/programs/vim.nix
+++ b/.config/home-manager/programs/vim.nix
@@ -1,8 +1,38 @@
 { pkgs, ... }:
 
+let
+  buildVimPlugin = src: (pkgs.vimUtils.buildVimPlugin {
+    name = "${src.owner}/${src.repo}";
+    src = pkgs.fetchFromGitHub src;
+  });
+  customVimPlugins = map buildVimPlugin [
+    {
+      owner = "itchyny";
+      repo = "lightline";
+      rev = "1c6b455c0445b8bc1c4c16ba569a43c6348411cc";
+      hash = "sha256-aoJR1l+N1kyY5HX0jgCIJfYbAmg/H8vb8mwjDqNnrTc=";
+    }
+    {
+      owner = " joshdick";
+      repo = "onedark.vim";
+      rev = "57b77747694ea5676c3ca0eeaf9567dc499730c0";
+      hash = "sha256-rt/VKABAfxyFBKNerZiswWDaBrusrn7WaI1jHbn3I/s=";
+    }
+    {
+      owner = "pineapplegiant";
+      repo = "spaceduck";
+      rev = "350491f19343b24fa85809242089caa02d4dadce";
+      hash = "sha256-lE8y9BA2a4y0B6O3+NyOS7numoltmzhArgwTAner2fE=";
+    }
+  ];
+in
 {
   enable = true;
   packageConfigurable = pkgs.vim;
+  plugins = with pkgs.vimPlugins; [
+    nerdtree
+    gitgutter
+  ] ++ customVimPlugins;
   # ホームディレクトリにあるだけでは読み込まれない
   extraConfig =
     let

--- a/.config/home-manager/programs/vim.nix
+++ b/.config/home-manager/programs/vim.nix
@@ -1,8 +1,9 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   enable = true;
-  # TODO: ホームディレクトリにあるだけでは読み込まれない
+  packageConfigurable = pkgs.vim;
+  # ホームディレクトリにあるだけでは読み込まれない
   extraConfig =
     let
       vimrc = builtins.toString ../../../.vimrc;

--- a/.vimrc
+++ b/.vimrc
@@ -1,42 +1,9 @@
 if &compatible
-  " Be improved
+  " Disable compatibility mode for `vi`
   set nocompatible
 endif
 
-" Required:
-set runtimepath+=~/.vim/dein/repos/github.com/Shougo/dein.vim
-
-" Required:
-if dein#load_state('~/.vim/dein')
-  call dein#begin('~/.vim/dein')
-  " Required:
-  call dein#add('~/.vim/dein/repos/github.com/Shougo/dein.vim')
-
-  " Add or remove your plugins here like this:
-  call dein#add('preservim/nerdtree')
-  call dein#add('itchyny/lightline.vim')
-  call dein#add('joshdick/onedark.vim')
-  call dein#add('pineapplegiant/spaceduck')
-  call dein#add('airblade/vim-gitgutter')
-
-  " Required:
-  call dein#end()
-  call dein#save_state()
-  let g:dein#auto_recache = 1
-endif
-
-" Required:
 filetype plugin indent on
-
-" install not installed plugins on startup.
-if dein#check_install()
-  call dein#install()
-endif
-
-call map(dein#check_clean(), "delete(v:val, 'rf')")
-call dein#recache_runtimepath()
-
-" -------------------- End dein Scripts -------------------------
 
 " -------------------- NerdTree --------------------
 
@@ -51,8 +18,6 @@ autocmd VimEnter * wincmd p
 map <silent><C-e> :NERDTreeFocus<CR>
 " map <silent><C-e> :NERDTreeToggle<CR>
 map <silent><C-f> :NERDTreeFind<CR>
-
-" -------------------- vim-gitgutter --------------------
 
 " .swp ファイルを作成するまでの時間 (ms)
 set updatetime=500

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ init: add-tools install # Install all languages & their packages
 # tools ----------------------------------------------------------------------------------------------------
 
 .PHONY: add-tools
-add-tools: add-nix add-home-manager add-dein-vim # Add developing tools
+add-tools: add-nix add-home-manager # Add developing tools
 
 .PHONY: remove-tools
-remove-tools: remove-nix remove-dein-vim # Remove developing tools
+remove-tools: remove-nix # Remove developing tools
 
 .PHONY: add-nix
 add-nix: _print-airplane # Install nix
@@ -42,17 +42,6 @@ add-home-manager: _print-airplane _prepare-home-manager # Add home-manager
 	source ${PATH_SCRIPT}; \
 	nix --extra-experimental-features "nix-command flakes" run home-manager/master -- init --switch ./.config/home-manager
 	echo "✅ home-manager has been installed successfully!";
-
-
-.PHONY: add-dein-vim
-add-dein-vim: _print-airplane # Add dein.vim
-	curl https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh | bash -s ~/.vim/dein
-	@echo "✅ dein.vim has been installed successfully!"
-
-.PHONY: remove-dein-vim
-remove-dein-vim: _print-goodbye # Remove dein.vim
-	sudo rm -rf ~/.vim/dein
-	@echo "✅ dein.vim has been uninstalled successfully!"
 
 
 .PHONY: add-bash-it

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ $ sudo pacman -Syu && sudo pacman -S git make gcc curl wget unzip openssh
 - `add-tools`
   - `add-nix` - add Nix
   - `add-home-manager` - add home-manager
-  - `add-dein-vim` - add dein.vim
 - `install`
   - `install-asdf-langs` - install asdf-vm (Node.js, yarn, Terraform & etc.)
   - `install-nim` - install Nim


### PR DESCRIPTION
## 概要

- reslove #116 - https://github.com/nokazn/dotfiles/pull/117/commits/0665da723b1471d01627fbceec91dca5f9dfa219
- Nixでvimプラグインも管理することにした (ありがとうdein.vim) - https://github.com/nokazn/dotfiles/pull/117/commits/d4feec4f4cd4241c9e5d59c3b74106edbd04958d

## 詳細

`pkgs.vim-full`を`pkgs.vim`に置き換えた。差分は以下の通り。

```diff
4c4
< Huge version without GUI.  Features included (+) or not (-):
---
> Huge version with GTK3 GUI.  Features included (+) or not (-):
25c25
< -balloon_eval
---
> +balloon_eval
33c33
< -browse
---
> +browse
49c49
< -toolbar
---
> +toolbar
54c54
< -clientserver
---
> +clientserver
58c58
< -clipboard
---
> +clipboard
72c72
< -python3
---
> +python3
88c88
< -ruby
---
> +ruby
91c91
< -lua
---
> +lua
98c98
< +dialog_con
---
> +dialog_con_gui
104,105c104,105
< -sodium
< -X11
---
> +sodium
> +X11
110,111c110,111
< -dnd
< -mouseshape
---
> +dnd
> +mouseshape
117c117
< -xim
---
> +xim
121c121
< -xpm
---
> +xpm
129c129
< -xterm_clipboard
---
> +xterm_clipboard
140a141,143
>   system gvimrc file: "$VIM/gvimrc"
>     user gvimrc file: "$HOME/.gvimrc"
> 2nd user gvimrc file: "~/.vim/gvimrc"
141a145
>     system menu file: "$VIMRUNTIME/menu.vim"
143,145c147,149
< /nix/store/w9k7cxllh05d8r7hy5j5kf48k80zgfg3-vim-9.0.2116/share/vim"
< Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
< Linking: gcc -Wl,--as-needed -o vim -lm -ltinfo
---
> /nix/store/99qya587fwmn5vqzwglj7np7hxqmk0y9-vim-full-9.0.2116/share/vim"
> Compilation: see nix-store --read-log /nix/store/99qya587fwmn5vqzwglj7np7hxqmk0y9-vim-full-9.0.2116
> Linking: see nix-store --read-log /nix/store/99qya587fwmn5vqzwglj7np7hxqmk0y9-vim-full-9.0.2116
```