### PR TITLE
Update & add CI actions

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,18 @@
+name: build-macos
+
+on:
+  # TODO: unable to build in x86_64-darwin
+  workflow_dispatch:
+
+jobs:
+  build-darwin:
+    runs-on: macos-12
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - name: Build
+        run: make apply/darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -23,6 +24,7 @@ jobs:
 
   build-wsl:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -34,14 +36,3 @@ jobs:
           ./scripts/backup.sh ./modules/files/files.txt
           nix run home-manager/release-23.11 -- switch --flake '.#runner-wsl'
           echo "✅ home-manager has been applied successfully!"
-
-  build-darwin:
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: DeterminateSystems/flake-checker-action@main
-      - name: Build
-        run: make apply/darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: |
           ./scripts/backup.sh ./modules/files/files.txt
-          nix run home-manager/release-23.11 -- switch --flake '.#wsl'
+          nix run home-manager/release-23.11 -- switch --flake '.#runner-wsl'
           echo "✅ home-manager has been applied successfully!"
 
   build-darwin:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: build
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build
+        run: make apply/user
+
+  build-wsl:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build
+        run: |
+          ./scripts/backup.sh ./modules/files/files.txt
+          nix run home-manager/release-23.11 -- switch --flake '.#wsl'
+          echo "✅ home-manager has been applied successfully!"
+
+  build-darwin:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build
+        run: make apply/darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
       - name: Build
         run: make apply/user
 
@@ -25,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
       - name: Build
         run: |
           ./scripts/backup.sh ./modules/files/files.txt
@@ -37,5 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
       - name: Build
         run: make apply/darwin

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -7,21 +7,22 @@ on:
   pull_request:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   check-by-pre-commit:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
 
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.1
 
   check-shell-scripts:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run shellcheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/udpate.yml
+++ b/.github/workflows/udpate.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Generate branch date
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Update npm packages list
@@ -43,7 +43,7 @@ jobs:
             -p nixpkgs-fmt \
             --command "node2nix -i ./packages.json -o ./packages.nix --nodejs-18 && find . -type f | grep -e "\.nix$" | xargs nixpkgs-fmt"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           branch: deps/update-npm-packages-list
           branch-suffix: timestamp

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ apply/user: # Run `home-manager switch` for user environment
 	$(SCRIPTS_DIR)/backup.sh ./modules/files/files.txt
 	if [[ $$(uname -r) =~ microsoft ]]; then \
 		source $(PATH_SCRIPT) && $(NIX) run \
-			home-manager/release-23.11 -- switch --flake .#wsl; \
+			home-manager/release-23.11 -- switch --flake .#$${USER}-wsl; \
 	else \
 		source $(PATH_SCRIPT) && $(NIX) run \
 			home-manager/release-23.11 -- switch --flake .; \
@@ -98,8 +98,13 @@ apply/user: # Run `home-manager switch` for user environment
 .PHONY: apply/darwin
 apply/darwin: # Run `nix-darwin switch`
 	$(SCRIPTS_DIR)/backup.sh ./modules/files/files.txt --absolute
-	source $(PATH_SCRIPT) && $(NIX) run \
-		nix-darwin -- switch --flake .#aarch64-darwin
+	if [[ $$(arch) =~ arm64 ]]; then \
+		source $(PATH_SCRIPT) && $(NIX) run \
+			nix-darwin -- switch --flake .#aarch64-darwin-$${USER}; \
+	else \
+		source $(PATH_SCRIPT) && $(NIX) run \
+			nix-darwin -- switch --flake .#x86_64-darwin-$${USER}; \
+	fi
 	$(SCRIPTS_DIR)/writable-files.sh ./modules/files/files.txt
 	@echo "✅ nix-darwin has been applied successfully!"
 

--- a/home/darwin.nix
+++ b/home/darwin.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, user, nix, meta, ... }:
+{ pkgs, lib, nix, meta, ... }:
 
 let
   nixPackages = import ../modules/packages { inherit pkgs lib meta; };
@@ -6,7 +6,6 @@ let
 in
 {
   home = {
-    username = user.name;
     # This value determines the Home Manager release that your
     # configuration is compatible with. This helps avoid breakage
     # when a new Home Manager release introduces backwards

--- a/modules/files/default.nix
+++ b/modules/files/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, meta, ... }:
 
 let
   fileSourceList =
@@ -24,14 +24,17 @@ let
           )
           (lib.splitString "\n" files);
       onChange = file:
-        if pkgs.stdenv.isDarwin then
-          ''
-            /usr/bin/sudo /bin/chmod -h +w '${file}'
-          ''
-        else
-          ''
-            chmod +w '${file}'
-          '';
+        (lib.optionalString
+          (!meta.isCi)
+          (if pkgs.stdenv.isDarwin then
+            ''
+              /usr/bin/sudo /bin/chmod -h +w '${file}'
+            ''
+          else
+            ''
+              chmod +w '${file}'
+            '')
+        );
     in
     builtins.map
       (file: {


### PR DESCRIPTION
CIでx86_64のmacOSのビルドがうまくいかないが、aarch64環境のローカルでは成功する。
→ macOSのビルドのチェックは手動でのみ発火させるようにする。