### PR TITLE
deps: upgraade flake.lock mannualy + update incompatible settings

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           cd ./modules/node;
           nix-shell -p nodePackages.node2nix \
-            -p nixpkgs-fmt \
-            --command "node2nix -i ./packages.json -o ./packages.nix --nodejs-18 && find . -type f | grep -e "\.nix$" | xargs nixpkgs-fmt"
+            -p nixfmt \
+            --command "node2nix -i ./packages.json -o ./packages.nix --nodejs-18 && find . -type f | grep -e "\.nix$" | xargs nixfmt"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.vscode/extensions.bk.json
+++ b/.vscode/extensions.bk.json
@@ -569,6 +569,14 @@
   },
   {
     "identifier": {
+      "id": "vscode.terminal-suggest"
+    },
+    "preRelease": false,
+    "version": "1.0.1",
+    "pinned": false
+  },
+  {
+    "identifier": {
       "id": "vscode.testing-editor-contributions"
     },
     "version": "1.0.0",
@@ -733,6 +741,26 @@
   },
   {
     "identifier": {
+      "id": "actionforge.actionforge",
+      "uuid": "e9969f21-919b-4384-9dfd-cb222b425ece"
+    },
+    "preRelease": false,
+    "version": "0.9.84",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "adpyke.vscode-sql-formatter",
+      "uuid": "ac70a31d-d9ab-417b-b259-baf7cd9d6cb0"
+    },
+    "preRelease": false,
+    "version": "1.4.4",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
       "id": "albymor.increment-selection",
       "uuid": "3fe4660f-1dcb-47d4-8f7e-1a22a16b2d5e"
     },
@@ -779,8 +807,18 @@
       "id": "astro-build.astro-vscode",
       "uuid": "1fbbc8b0-7432-4b7e-8774-3336151da2f3"
     },
-    "version": "2.8.5",
     "preRelease": false,
+    "version": "2.15.4",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "asuka.insertnumbers",
+      "uuid": "1bd4f828-df27-4316-952d-2d89c42e6b16"
+    },
+    "preRelease": false,
+    "version": "0.9.1",
     "pinned": false,
     "installed": true
   },
@@ -791,16 +829,6 @@
     },
     "preRelease": false,
     "version": "0.5.0",
-    "pinned": false,
-    "installed": true
-  },
-  {
-    "identifier": {
-      "id": "b4dm4n.nixpkgs-fmt",
-      "uuid": "dee02e97-562f-4c72-8626-0566e7e522f2"
-    },
-    "version": "0.0.1",
-    "preRelease": false,
     "pinned": false,
     "installed": true
   },
@@ -856,16 +884,6 @@
   },
   {
     "identifier": {
-      "id": "biomejs.biome",
-      "uuid": "2c992d35-3965-4369-856e-fdfbb0af2ce2"
-    },
-    "preRelease": false,
-    "version": "2.2.2",
-    "pinned": false,
-    "installed": true
-  },
-  {
-    "identifier": {
       "id": "bradgashler.htmltagwrap",
       "uuid": "c16f95f6-9b42-4a24-9bf4-245d4ea54fc5"
     },
@@ -881,6 +899,26 @@
     },
     "version": "0.10.5",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "bradymholt.pgformatter",
+      "uuid": "849ffb6c-e755-4e6e-adc2-c33eaaf0d0fc"
+    },
+    "preRelease": false,
+    "version": "1.28.1",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "brettm12345.nixfmt-vscode",
+      "uuid": "1aa812d9-007d-46e3-ae73-91210cf36115"
+    },
+    "preRelease": false,
+    "version": "0.0.1",
     "pinned": false,
     "installed": true
   },
@@ -970,17 +1008,7 @@
       "uuid": "583b2b34-2c1e-4634-8c0b-0b82e283ea3a"
     },
     "preRelease": false,
-    "version": "2.4.4",
-    "pinned": false,
-    "installed": true
-  },
-  {
-    "identifier": {
-      "id": "denoland.vscode-deno",
-      "uuid": "91881318-cfd0-4905-adb7-f4e431ca1ead"
-    },
-    "version": "3.36.0",
-    "preRelease": false,
+    "version": "3.0.10",
     "pinned": false,
     "installed": true
   },
@@ -989,8 +1017,8 @@
       "id": "dprint.dprint",
       "uuid": "a71f21fc-951b-4829-92f5-ba423b77109f"
     },
-    "version": "0.16.0",
     "preRelease": false,
+    "version": "0.16.3",
     "pinned": false,
     "installed": true
   },
@@ -1020,12 +1048,11 @@
       "uuid": "4de763bd-505d-4978-9575-2b7696ecf94e"
     },
     "preRelease": false,
-    "version": "15.5.1",
+    "version": "16.3.2",
     "pinned": false,
     "installed": true,
     "state": {
-      "gitlens:views:welcome:visible": false,
-      "gitlens:synced:version": "15.5.1"
+      "gitlens:synced:version": "16.3.2"
     }
   },
   {
@@ -1055,6 +1082,26 @@
     },
     "preRelease": false,
     "version": "10.1.0",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "fcrespo82.markdown-table-formatter",
+      "uuid": "db9e305f-2d5a-44a5-97f7-91d4f2199a81"
+    },
+    "preRelease": false,
+    "version": "3.0.0",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "fireside21.cshtml",
+      "uuid": "24fc5c70-edac-4484-9c8f-3feb012e40db"
+    },
+    "preRelease": false,
+    "version": "0.1.3",
     "pinned": false,
     "installed": true
   },
@@ -1104,7 +1151,7 @@
       "uuid": "69ddd764-339a-4ecc-97c1-9c4ece58e36d"
     },
     "preRelease": false,
-    "version": "0.96.0",
+    "version": "0.104.1",
     "pinned": false,
     "installed": true,
     "state": {
@@ -1217,7 +1264,7 @@
       "uuid": "d95cb424-7a5a-4e08-9698-107d6fd590cf"
     },
     "preRelease": false,
-    "version": "2.17.5",
+    "version": "2.18.1",
     "pinned": false,
     "installed": true
   },
@@ -1263,6 +1310,26 @@
   },
   {
     "identifier": {
+      "id": "jrieken.vscode-pr-pinger",
+      "uuid": "4ea1571f-9bf1-43d9-aa81-0018435c351f"
+    },
+    "preRelease": false,
+    "version": "0.0.6",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "kaiwood.center-editor-window",
+      "uuid": "02152492-08a6-4c83-a1a7-b077733bdd7c"
+    },
+    "preRelease": false,
+    "version": "2.3.0",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
       "id": "kamadorueda.alejandra",
       "uuid": "90c308b2-fb23-42d4-a902-c7a56b62fe5a"
     },
@@ -1283,11 +1350,41 @@
   },
   {
     "identifier": {
+      "id": "koichisasada.vscode-rdbg",
+      "uuid": "24c6dcf1-6c66-4c4e-be43-d48d0d9c5a41"
+    },
+    "preRelease": false,
+    "version": "0.2.2",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
       "id": "kuscamara.electron",
       "uuid": "975d187d-7d95-4292-92ef-ad9e8f083ca3"
     },
     "version": "0.2.6",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "luqimin.tiny-light",
+      "uuid": "327262c5-9b97-472c-805c-4f0fe8251e57"
+    },
+    "preRelease": false,
+    "version": "2.0.9",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "marcostazi.vs-code-vagrantfile",
+      "uuid": "d0febfc8-15fa-4951-bad7-ad5c9682af4a"
+    },
+    "preRelease": false,
+    "version": "0.0.7",
     "pinned": false,
     "installed": true
   },
@@ -1346,8 +1443,8 @@
       "id": "ms-azuretools.vscode-docker",
       "uuid": "0479fc1c-3d67-49f9-b087-fb9069afe48f"
     },
-    "version": "1.29.0",
     "preRelease": false,
+    "version": "1.29.3",
     "pinned": false,
     "installed": true
   },
@@ -1358,6 +1455,16 @@
     },
     "preRelease": false,
     "version": "1.90.2024061209",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "ms-dotnettools.vscode-dotnet-runtime",
+      "uuid": "1aab81a1-b3d9-4aef-976b-577d5d90fe3f"
+    },
+    "preRelease": false,
+    "version": "2.1.5",
     "pinned": false,
     "installed": true
   },
@@ -1376,8 +1483,8 @@
       "id": "ms-python.isort",
       "uuid": "4ad0ce32-ff3f-49f0-83b5-93e5dc00cfff"
     },
-    "version": "2023.10.1",
     "preRelease": false,
+    "version": "2023.10.1",
     "pinned": false,
     "installed": true
   },
@@ -1417,7 +1524,7 @@
       "uuid": "93ce222b-5f6f-49b7-9ab1-a0463c6238df"
     },
     "preRelease": false,
-    "version": "0.384.0",
+    "version": "0.397.0",
     "pinned": false,
     "installed": true,
     "state": {
@@ -1564,8 +1671,8 @@
       "id": "ms-vscode.powershell",
       "uuid": "40d39ce9-c381-47a0-80c8-a6661f731eab"
     },
-    "version": "2024.0.0",
     "preRelease": false,
+    "version": "2024.4.0",
     "pinned": false,
     "installed": true
   },
@@ -1610,6 +1717,16 @@
   },
   {
     "identifier": {
+      "id": "ms-vscode.vscode-github-issue-notebooks",
+      "uuid": "3be1cece-c179-4cd6-b59b-3bae29e1a166"
+    },
+    "preRelease": false,
+    "version": "0.0.130",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
       "id": "ms-vscode.vscode-js-profile-table",
       "uuid": "7e52b41b-71ad-457b-ab7e-0620f1fc4feb"
     },
@@ -1634,6 +1751,26 @@
     },
     "version": "1.0.5918",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "mtxr.sqltools",
+      "uuid": "6a2bbab0-d8f0-43fa-9b26-e6a3b7892a0b"
+    },
+    "preRelease": false,
+    "version": "0.28.3",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "mylesmurphy.prettify-ts",
+      "uuid": "c988487b-df58-4518-83d9-cfbf0483493e"
+    },
+    "preRelease": false,
+    "version": "0.1.5",
     "pinned": false,
     "installed": true
   },
@@ -1682,8 +1819,8 @@
       "id": "peterschmalfeldt.explorer-exclude",
       "uuid": "cd42c488-2afb-4d43-a5a5-98b1e482978a"
     },
-    "version": "1.3.2",
     "preRelease": false,
+    "version": "1.3.2",
     "pinned": false,
     "installed": true
   },
@@ -1694,6 +1831,16 @@
     },
     "version": "1.10.3",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "rafael-avalos.light-colors-theme",
+      "uuid": "68959ce2-b9e3-4a2f-89fc-93cb41e9222f"
+    },
+    "preRelease": false,
+    "version": "1.1.1",
     "pinned": false,
     "installed": true
   },
@@ -1775,8 +1922,8 @@
       "id": "s-nlf-fh.glassit",
       "uuid": "7f4f553c-204c-42fe-9b4d-7a3f11f7335b"
     },
-    "version": "0.2.6",
     "preRelease": false,
+    "version": "0.2.6",
     "pinned": false,
     "installed": true
   },
@@ -1817,6 +1964,16 @@
     },
     "preRelease": false,
     "version": "0.28.0",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "shahzaibkhalid.shaizei-light",
+      "uuid": "f2029ddf-f604-4672-9d77-9e91d70a548f"
+    },
+    "preRelease": false,
+    "version": "1.3.0",
     "pinned": false,
     "installed": true
   },
@@ -1882,11 +2039,21 @@
   },
   {
     "identifier": {
+      "id": "sorbet.sorbet-vscode-extension",
+      "uuid": "67d58bf5-9c4f-495f-bee0-d1d3f5898a8b"
+    },
+    "preRelease": false,
+    "version": "0.3.37",
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
       "id": "streetsidesoftware.code-spell-checker",
       "uuid": "f6dbd813-b0a0-42c1-90ea-10dde9d925a7"
     },
-    "version": "3.0.1",
     "preRelease": false,
+    "version": "4.0.21",
     "pinned": false,
     "installed": true
   },
@@ -1907,16 +2074,6 @@
     },
     "preRelease": false,
     "version": "1.7.8",
-    "pinned": false,
-    "installed": true
-  },
-  {
-    "identifier": {
-      "id": "stylelint.vscode-stylelint",
-      "uuid": "ec35b5a3-9802-4c68-b5ff-e85f19ec0977"
-    },
-    "preRelease": false,
-    "version": "1.3.0",
     "pinned": false,
     "installed": true
   },
@@ -2123,10 +2280,10 @@
   {
     "identifier": {
       "id": "vue.volar",
-      "uuid": "a5223b43-8621-4351-a14e-3d560f85f277"
+      "uuid": "a95ee795-1576-4ffa-acda-8d6e6a95c584"
     },
     "preRelease": false,
-    "version": "2.0.10",
+    "version": "2.1.6",
     "pinned": false,
     "installed": true
   },
@@ -2137,6 +2294,16 @@
     },
     "version": "1.0.5",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "well-ar.plantuml",
+      "uuid": "fd667480-335c-42d9-8c0a-73fe74829095"
+    },
+    "preRelease": false,
+    "version": "2.17.6",
     "pinned": false,
     "installed": true
   },
@@ -2167,6 +2334,16 @@
     },
     "version": "0.5.3",
     "preRelease": false,
+    "pinned": false,
+    "installed": true
+  },
+  {
+    "identifier": {
+      "id": "yzane.markdown-pdf",
+      "uuid": "f015bc3c-a098-4245-8765-615e002e09ab"
+    },
+    "preRelease": false,
+    "version": "1.5.0",
     "pinned": false,
     "installed": true
   }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "timonwong.shellcheck",
     "mkhl.shfmt",
-    "B4dM4n.nixpkgs-fmt",
-    "sumneko.lua"
+    "brettm12345.nixfmt-vscode",
+    "sumneko.lua",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   // Nix
   "[nix]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "B4dM4n.nixpkgs-fmt"
+    "editor.defaultFormatter": "brettm12345.nixfmt-vscode"
   },
   "nixEnvSelector.nixFile": "${workspaceFolder}/flake.nix",
   // shell script

--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,8 @@ update/nix: # Update Nix package manager
 update/npm-packages-list: # Generate Nix packages list for npm packages
 	cd ./modules/node; \
 	nix-shell -p nodePackages.node2nix \
-    -p nixpkgs-fmt \
-    --command 'node2nix -i ./packages.json -o ./packages.nix --nodejs-18 && find . -type f | grep -e "\.nix$$" | xargs nixpkgs-fmt' && exit
+    -p nixfmt \
+    --command 'node2nix -i ./packages.json -o ./packages.nix --nodejs-18 && find . -type f | grep -e "\.nix$$" | xargs nixfmt' && exit
 
 .PHONY: update/vscode-settings/darwin
 update/vscode-settings/darwin: # Update VSCode settings.json & keybindings.json for Darwin
@@ -169,7 +169,7 @@ update/vscode-settings/windows: # Update VSCode settings.json & keybindings.json
 # utilities ----------------------------------------------------------------------------------------------------
 
 .PHONY: check
-check: check/shellcheck check/shfmt check/nixpkgs-fmt # Check by all `check/*` tasks
+check: check/shellcheck check/shfmt check/nixfmt # Check by all `check/*` tasks
 
 .PHONY: check/shellcheck
 check/shellcheck: # Check schell scripts
@@ -179,16 +179,16 @@ check/shellcheck: # Check schell scripts
 check/shfmt: # Check wheter schell scripts are formatted
 	shfmt --diff $(SHELL_FILES)
 
-.PHONY: check/nixpkgs-fmt
-check/nixpkgs-fmt: # Check `.nix` files
-	nixpkgs-fmt $(NIX_FILES) --check
+.PHONY: check/nixfmt
+check/nixfmt: # Check `.nix` files
+	nixfmt $(NIX_FILES) --check
 
 .PHONY: check/dprint
 check/dprint: # Check by dprint
 	dprint check
 
 .PHONY: fix
-fix: fix/shellcheck fix/shfmt fix/nixpkgs-fmt # Fix by all `fix/*` tasks
+fix: fix/shellcheck fix/shfmt fix/nixfmt # Fix by all `fix/*` tasks
 
 .PHONY: fix/shellcheck
 fix/shellcheck: # Fix schell scripts if possible
@@ -199,9 +199,9 @@ fix/shellcheck: # Fix schell scripts if possible
 fix/shfmt: # Format schell scripts
 	shfmt --write $(SHELL_FILES)
 
-.PHONY: fix/nixpkgs-fmt
-fix/nixpkgs-fmt: # Format `.nix` files
-	nixpkgs-fmt $(NIX_FILES)
+.PHONY: fix/nixfmt
+fix/nixfmt: # Format `.nix` files
+	nixfmt $(NIX_FILES)
 
 .PHONY: fix/dprint
 fix/dprint: # Format by dprint

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1722113426,
-        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727111745,
-        "narHash": "sha256-EYLvFRoTPWtD+3uDg2wwQvlz88OrIr3zld+jFE5gDcY=",
+        "lastModified": 1740265252,
+        "narHash": "sha256-+LFsCsIUF/pJWL9S21m5NLcK5bgwRB4MwfV0Iu7tggY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21c021862fa696c8199934e2153214ab57150cb6",
+        "rev": "fb568d75cf6c81f30d49eeb73787e9b56454ba16",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727003835,
-        "narHash": "sha256-Cfllbt/ADfO8oxbT984MhPHR6FJBaglsr1SxtDGbpec=",
+        "lastModified": 1739933872,
+        "narHash": "sha256-UhuvTR4OrWR+WBaRCZm4YMkvjJhZ1KZo/jRjE41m+Ek=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bd7d1e3912d40f799c5c0f7e5820ec950f1e0b3d",
+        "rev": "6ab392f626a19f1122d1955c401286e1b7cf6b53",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1727089097,
-        "narHash": "sha256-ZMHMThPsthhUREwDebXw7GX45bJnBCVbfnH1g5iuSPc=",
+        "lastModified": 1740019556,
+        "narHash": "sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "568bfef547c14ca438c56a0bece08b8bb2b71a9c",
+        "rev": "dad564433178067be1fbdfcce23b546254b6d641",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726937504,
-        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,7 @@
               gnumake
               shellcheck
               shfmt
-              nixpkgs-fmt
+              nixfmt-rfc-style
               yamlfmt
               dprint
               pre-commit

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -1,17 +1,17 @@
-{ meta, ... }:
+{ meta, pkgs, ... }:
 
 {
-  # necessary for nix-darwin
-  services.nix-daemon.enable = true;
-
   users.users = {
     ${meta.user.name} = {
       home = "/Users/${meta.user.name}";
-      shell = "zsh";
+      shell = pkgs.zsh;
     };
   };
 
   homebrew = if meta.isCi then { } else import ./homebrew.nix { };
+
+  # For compatibility for lecacy Nix build uiser group ID by nix-darwin
+  ids.gids.nixbld = 30000;
 
   system = {
     stateVersion = 5;

--- a/modules/node/default.nix
+++ b/modules/node/default.nix
@@ -11,7 +11,7 @@ let
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
   };
 in
 import ./packages.nix {

--- a/modules/node/packages.nix
+++ b/modules/node/packages.nix
@@ -40,40 +40,13 @@ let
         sha512 = "3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==";
       };
     };
-    "@nodelib/fs.scandir-2.1.5" = {
-      name = "_at_nodelib_slash_fs.scandir";
-      packageName = "@nodelib/fs.scandir";
-      version = "2.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz";
-        sha512 = "vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==";
-      };
-    };
-    "@nodelib/fs.stat-2.0.5" = {
-      name = "_at_nodelib_slash_fs.stat";
-      packageName = "@nodelib/fs.stat";
-      version = "2.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz";
-        sha512 = "RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==";
-      };
-    };
-    "@nodelib/fs.walk-1.2.8" = {
-      name = "_at_nodelib_slash_fs.walk";
-      packageName = "@nodelib/fs.walk";
-      version = "1.2.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz";
-        sha512 = "oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==";
-      };
-    };
-    "@swc/core-1.7.28" = {
+    "@swc/core-1.10.18" = {
       name = "_at_swc_slash_core";
       packageName = "@swc/core";
-      version = "1.7.28";
+      version = "1.10.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@swc/core/-/core-1.7.28.tgz";
-        sha512 = "XapcMgsOS0cKh01AFEj+qXOk6KM4NZhp7a5vPicdhkRR8RzvjrCa7DTtijMxfotU8bqaEHguxmiIag2HUlT8QQ==";
+        url = "https://registry.npmjs.org/@swc/core/-/core-1.10.18.tgz";
+        sha512 = "IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==";
       };
     };
     "@swc/counter-0.1.3" = {
@@ -85,31 +58,31 @@ let
         sha512 = "e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==";
       };
     };
-    "@swc/helpers-0.5.13" = {
+    "@swc/helpers-0.5.15" = {
       name = "_at_swc_slash_helpers";
       packageName = "@swc/helpers";
-      version = "0.5.13";
+      version = "0.5.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz";
-        sha512 = "UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==";
+        url = "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz";
+        sha512 = "JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==";
       };
     };
-    "@swc/types-0.1.12" = {
+    "@swc/types-0.1.17" = {
       name = "_at_swc_slash_types";
       packageName = "@swc/types";
-      version = "0.1.12";
+      version = "0.1.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz";
-        sha512 = "wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==";
+        url = "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz";
+        sha512 = "V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==";
       };
     };
-    "@swc/wasm-1.7.28" = {
+    "@swc/wasm-1.10.18" = {
       name = "_at_swc_slash_wasm";
       packageName = "@swc/wasm";
-      version = "1.7.28";
+      version = "1.10.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@swc/wasm/-/wasm-1.7.28.tgz";
-        sha512 = "qZyUeU+6cipcs2QEeRCji56AMyBh+CFfBB+yrAG6VuPoNild2UmcN83Y7OcodscJKTqDxFBvpG+t3C4KgjsNCA==";
+        url = "https://registry.npmjs.org/@swc/wasm/-/wasm-1.10.18.tgz";
+        sha512 = "TgoMYjQ2/9UfUaw7WuKj7Svew6kaNOqkjV4nKoc2tf34e+7GxL2KPoXvM2b1RkPxNocv85glcQpS9KMk8FqpBA==";
       };
     };
     "@tsconfig/node10-1.0.11" = {
@@ -148,22 +121,22 @@ let
         sha512 = "vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==";
       };
     };
-    "@types/node-22.6.1" = {
+    "@types/node-22.13.5" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "22.6.1";
+      version = "22.13.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz";
-        sha512 = "V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz";
+        sha512 = "+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==";
       };
     };
-    "acorn-8.12.1" = {
+    "acorn-8.14.0" = {
       name = "acorn";
       packageName = "acorn";
-      version = "8.12.1";
+      version = "8.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz";
-        sha512 = "tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz";
+        sha512 = "cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==";
       };
     };
     "acorn-walk-8.3.4" = {
@@ -211,22 +184,22 @@ let
         sha512 = "NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==";
       };
     };
-    "braces-3.0.3" = {
-      name = "braces";
-      packageName = "braces";
-      version = "3.0.3";
+    "call-bind-apply-helpers-1.0.2" = {
+      name = "call-bind-apply-helpers";
+      packageName = "call-bind-apply-helpers";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz";
-        sha512 = "yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==";
+        url = "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz";
+        sha512 = "Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==";
       };
     };
-    "call-bind-1.0.7" = {
-      name = "call-bind";
-      packageName = "call-bind";
-      version = "1.0.7";
+    "call-bound-1.0.3" = {
+      name = "call-bound";
+      packageName = "call-bound";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz";
-        sha512 = "GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==";
+        url = "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz";
+        sha512 = "YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==";
       };
     };
     "chalk-4.1.2" = {
@@ -283,15 +256,6 @@ let
         sha512 = "CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==";
       };
     };
-    "define-data-property-1.1.4" = {
-      name = "define-data-property";
-      packageName = "define-data-property";
-      version = "1.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz";
-        sha512 = "rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==";
-      };
-    };
     "detect-indent-7.0.1" = {
       name = "detect-indent";
       packageName = "detect-indent";
@@ -319,22 +283,22 @@ let
         sha512 = "58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==";
       };
     };
-    "dir-glob-3.0.1" = {
-      name = "dir-glob";
-      packageName = "dir-glob";
-      version = "3.0.1";
+    "dunder-proto-1.0.1" = {
+      name = "dunder-proto";
+      packageName = "dunder-proto";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz";
-        sha512 = "WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==";
+        url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
+        sha512 = "KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
       };
     };
-    "es-define-property-1.0.0" = {
+    "es-define-property-1.0.1" = {
       name = "es-define-property";
       packageName = "es-define-property";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz";
-        sha512 = "jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==";
+        url = "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz";
+        sha512 = "e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==";
       };
     };
     "es-errors-1.3.0" = {
@@ -346,6 +310,15 @@ let
         sha512 = "Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==";
       };
     };
+    "es-object-atoms-1.1.1" = {
+      name = "es-object-atoms";
+      packageName = "es-object-atoms";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz";
+        sha512 = "FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==";
+      };
+    };
     "eventemitter3-4.0.7" = {
       name = "eventemitter3";
       packageName = "eventemitter3";
@@ -355,31 +328,13 @@ let
         sha512 = "8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==";
       };
     };
-    "fast-glob-3.3.2" = {
-      name = "fast-glob";
-      packageName = "fast-glob";
-      version = "3.3.2";
+    "fdir-6.4.3" = {
+      name = "fdir";
+      packageName = "fdir";
+      version = "6.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz";
-        sha512 = "oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==";
-      };
-    };
-    "fastq-1.17.1" = {
-      name = "fastq";
-      packageName = "fastq";
-      version = "1.17.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz";
-        sha512 = "sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==";
-      };
-    };
-    "fill-range-7.1.1" = {
-      name = "fill-range";
-      packageName = "fill-range";
-      version = "7.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz";
-        sha512 = "YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==";
+        url = "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz";
+        sha512 = "PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==";
       };
     };
     "follow-redirects-1.15.9" = {
@@ -400,13 +355,22 @@ let
         sha512 = "7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==";
       };
     };
-    "get-intrinsic-1.2.4" = {
+    "get-intrinsic-1.3.0" = {
       name = "get-intrinsic";
       packageName = "get-intrinsic";
-      version = "1.2.4";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz";
-        sha512 = "5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==";
+        url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz";
+        sha512 = "9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==";
+      };
+    };
+    "get-proto-1.0.1" = {
+      name = "get-proto";
+      packageName = "get-proto";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz";
+        sha512 = "sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==";
       };
     };
     "get-stdin-9.0.0" = {
@@ -418,40 +382,22 @@ let
         sha512 = "dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==";
       };
     };
-    "git-hooks-list-3.1.0" = {
+    "git-hooks-list-3.2.0" = {
       name = "git-hooks-list";
       packageName = "git-hooks-list";
-      version = "3.1.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz";
-        sha512 = "LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==";
+        url = "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.2.0.tgz";
+        sha512 = "ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==";
       };
     };
-    "glob-parent-5.1.2" = {
-      name = "glob-parent";
-      packageName = "glob-parent";
-      version = "5.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz";
-        sha512 = "AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==";
-      };
-    };
-    "globby-13.2.2" = {
-      name = "globby";
-      packageName = "globby";
-      version = "13.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz";
-        sha512 = "Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==";
-      };
-    };
-    "gopd-1.0.1" = {
+    "gopd-1.2.0" = {
       name = "gopd";
       packageName = "gopd";
-      version = "1.0.1";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz";
-        sha512 = "d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==";
+        url = "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz";
+        sha512 = "ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==";
       };
     };
     "has-flag-4.0.0" = {
@@ -463,31 +409,13 @@ let
         sha512 = "EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
       };
     };
-    "has-property-descriptors-1.0.2" = {
-      name = "has-property-descriptors";
-      packageName = "has-property-descriptors";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz";
-        sha512 = "55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==";
-      };
-    };
-    "has-proto-1.0.3" = {
-      name = "has-proto";
-      packageName = "has-proto";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz";
-        sha512 = "SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==";
-      };
-    };
-    "has-symbols-1.0.3" = {
+    "has-symbols-1.1.0" = {
       name = "has-symbols";
       packageName = "has-symbols";
-      version = "1.0.3";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz";
-        sha512 = "l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==";
+        url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz";
+        sha512 = "1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==";
       };
     };
     "hasown-2.0.2" = {
@@ -535,42 +463,6 @@ let
         sha512 = "4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==";
       };
     };
-    "ignore-5.3.2" = {
-      name = "ignore";
-      packageName = "ignore";
-      version = "5.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz";
-        sha512 = "hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==";
-      };
-    };
-    "is-extglob-2.1.1" = {
-      name = "is-extglob";
-      packageName = "is-extglob";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
-        sha512 = "SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
-      };
-    };
-    "is-glob-4.0.3" = {
-      name = "is-glob";
-      packageName = "is-glob";
-      version = "4.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz";
-        sha512 = "xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
-      };
-    };
-    "is-number-7.0.0" = {
-      name = "is-number";
-      packageName = "is-number";
-      version = "7.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz";
-        sha512 = "41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==";
-      };
-    };
     "is-plain-obj-4.1.0" = {
       name = "is-plain-obj";
       packageName = "is-plain-obj";
@@ -598,22 +490,13 @@ let
         sha512 = "s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==";
       };
     };
-    "merge2-1.4.1" = {
-      name = "merge2";
-      packageName = "merge2";
-      version = "1.4.1";
+    "math-intrinsics-1.1.0" = {
+      name = "math-intrinsics";
+      packageName = "math-intrinsics";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz";
-        sha512 = "8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==";
-      };
-    };
-    "micromatch-4.0.8" = {
-      name = "micromatch";
-      packageName = "micromatch";
-      version = "4.0.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz";
-        sha512 = "PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==";
+        url = "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz";
+        sha512 = "/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==";
       };
     };
     "mime-1.6.0" = {
@@ -652,13 +535,13 @@ let
         sha512 = "6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
       };
     };
-    "object-inspect-1.13.2" = {
+    "object-inspect-1.13.4" = {
       name = "object-inspect";
       packageName = "object-inspect";
-      version = "1.13.2";
+      version = "1.13.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz";
-        sha512 = "IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==";
+        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz";
+        sha512 = "W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==";
       };
     };
     "opener-1.5.2" = {
@@ -670,22 +553,13 @@ let
         sha512 = "ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==";
       };
     };
-    "path-type-4.0.0" = {
-      name = "path-type";
-      packageName = "path-type";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz";
-        sha512 = "gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==";
-      };
-    };
-    "picomatch-2.3.1" = {
+    "picomatch-4.0.2" = {
       name = "picomatch";
       packageName = "picomatch";
-      version = "2.3.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz";
-        sha512 = "JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
+        url = "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz";
+        sha512 = "M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==";
       };
     };
     "portfinder-1.0.32" = {
@@ -697,22 +571,13 @@ let
         sha512 = "on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==";
       };
     };
-    "qs-6.13.0" = {
+    "qs-6.14.0" = {
       name = "qs";
       packageName = "qs";
-      version = "6.13.0";
+      version = "6.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz";
-        sha512 = "+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==";
-      };
-    };
-    "queue-microtask-1.2.3" = {
-      name = "queue-microtask";
-      packageName = "queue-microtask";
-      version = "1.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz";
-        sha512 = "NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==";
+        url = "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz";
+        sha512 = "YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==";
       };
     };
     "requires-port-1.0.0" = {
@@ -722,24 +587,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz";
         sha512 = "KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==";
-      };
-    };
-    "reusify-1.0.4" = {
-      name = "reusify";
-      packageName = "reusify";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz";
-        sha512 = "U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==";
-      };
-    };
-    "run-parallel-1.2.0" = {
-      name = "run-parallel";
-      packageName = "run-parallel";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz";
-        sha512 = "5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==";
       };
     };
     "safe-buffer-5.1.2" = {
@@ -769,40 +616,49 @@ let
         sha512 = "AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==";
       };
     };
-    "semver-7.6.3" = {
+    "semver-7.7.1" = {
       name = "semver";
       packageName = "semver";
-      version = "7.6.3";
+      version = "7.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz";
-        sha512 = "oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==";
+        url = "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz";
+        sha512 = "hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==";
       };
     };
-    "set-function-length-1.2.2" = {
-      name = "set-function-length";
-      packageName = "set-function-length";
-      version = "1.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz";
-        sha512 = "pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==";
-      };
-    };
-    "side-channel-1.0.6" = {
+    "side-channel-1.1.0" = {
       name = "side-channel";
       packageName = "side-channel";
-      version = "1.0.6";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz";
-        sha512 = "fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==";
+        url = "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz";
+        sha512 = "ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==";
       };
     };
-    "slash-4.0.0" = {
-      name = "slash";
-      packageName = "slash";
-      version = "4.0.0";
+    "side-channel-list-1.0.0" = {
+      name = "side-channel-list";
+      packageName = "side-channel-list";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz";
-        sha512 = "3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==";
+        url = "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz";
+        sha512 = "FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==";
+      };
+    };
+    "side-channel-map-1.0.1" = {
+      name = "side-channel-map";
+      packageName = "side-channel-map";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz";
+        sha512 = "VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==";
+      };
+    };
+    "side-channel-weakmap-1.0.2" = {
+      name = "side-channel-weakmap";
+      packageName = "side-channel-weakmap";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz";
+        sha512 = "WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==";
       };
     };
     "sort-object-keys-1.1.3" = {
@@ -823,40 +679,40 @@ let
         sha512 = "qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
       };
     };
-    "to-regex-range-5.0.1" = {
-      name = "to-regex-range";
-      packageName = "to-regex-range";
-      version = "5.0.1";
+    "tinyglobby-0.2.12" = {
+      name = "tinyglobby";
+      packageName = "tinyglobby";
+      version = "0.2.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz";
-        sha512 = "65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==";
+        url = "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz";
+        sha512 = "qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==";
       };
     };
-    "tslib-2.7.0" = {
+    "tslib-2.8.1" = {
       name = "tslib";
       packageName = "tslib";
-      version = "2.7.0";
+      version = "2.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz";
-        sha512 = "gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==";
+        url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
+        sha512 = "oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
       };
     };
-    "typescript-5.6.2" = {
+    "typescript-5.7.3" = {
       name = "typescript";
       packageName = "typescript";
-      version = "5.6.2";
+      version = "5.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz";
-        sha512 = "NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz";
+        sha512 = "84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==";
       };
     };
-    "undici-types-6.19.8" = {
+    "undici-types-6.20.0" = {
       name = "undici-types";
       packageName = "undici-types";
-      version = "6.19.8";
+      version = "6.20.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz";
-        sha512 = "ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==";
+        url = "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz";
+        sha512 = "Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==";
       };
     };
     "union-0.5.0" = {
@@ -919,44 +775,48 @@ in
       sources."ansi-styles-4.3.0"
       sources."async-2.6.4"
       sources."basic-auth-2.0.1"
-      sources."call-bind-1.0.7"
+      sources."call-bind-apply-helpers-1.0.2"
+      sources."call-bound-1.0.3"
       sources."chalk-4.1.2"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."corser-2.0.1"
       sources."debug-3.2.7"
-      sources."define-data-property-1.1.4"
-      sources."es-define-property-1.0.0"
+      sources."dunder-proto-1.0.1"
+      sources."es-define-property-1.0.1"
       sources."es-errors-1.3.0"
+      sources."es-object-atoms-1.1.1"
       sources."eventemitter3-4.0.7"
       sources."follow-redirects-1.15.9"
       sources."function-bind-1.1.2"
-      sources."get-intrinsic-1.2.4"
-      sources."gopd-1.0.1"
+      sources."get-intrinsic-1.3.0"
+      sources."get-proto-1.0.1"
+      sources."gopd-1.2.0"
       sources."has-flag-4.0.0"
-      sources."has-property-descriptors-1.0.2"
-      sources."has-proto-1.0.3"
-      sources."has-symbols-1.0.3"
+      sources."has-symbols-1.1.0"
       sources."hasown-2.0.2"
       sources."he-1.2.0"
       sources."html-encoding-sniffer-3.0.0"
       sources."http-proxy-1.18.1"
       sources."iconv-lite-0.6.3"
       sources."lodash-4.17.21"
+      sources."math-intrinsics-1.1.0"
       sources."mime-1.6.0"
       sources."minimist-1.2.8"
       sources."mkdirp-0.5.6"
       sources."ms-2.1.3"
-      sources."object-inspect-1.13.2"
+      sources."object-inspect-1.13.4"
       sources."opener-1.5.2"
       sources."portfinder-1.0.32"
-      sources."qs-6.13.0"
+      sources."qs-6.14.0"
       sources."requires-port-1.0.0"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."secure-compare-3.0.1"
-      sources."set-function-length-1.2.2"
-      sources."side-channel-1.0.6"
+      sources."side-channel-1.1.0"
+      sources."side-channel-list-1.0.0"
+      sources."side-channel-map-1.0.1"
+      sources."side-channel-weakmap-1.0.2"
       sources."supports-color-7.2.0"
       sources."union-0.5.0"
       sources."url-join-4.0.1"
@@ -975,42 +835,22 @@ in
   sort-package-json = nodeEnv.buildNodePackage {
     name = "sort-package-json";
     packageName = "sort-package-json";
-    version = "2.10.1";
+    version = "2.14.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.10.1.tgz";
-      sha512 = "d76wfhgUuGypKqY72Unm5LFnMpACbdxXsLPcL27pOsSrmVqH3PztFp1uq+Z22suk15h7vXmTesuh2aEjdCqb5w==";
+      url = "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.14.0.tgz";
+      sha512 = "xBRdmMjFB/KW3l51mP31dhlaiFmqkHLfWTfZAno8prb/wbDxwBPWFpxB16GZbiPbYr3wL41H8Kx22QIDWRe8WQ==";
     };
     dependencies = [
-      sources."@nodelib/fs.scandir-2.1.5"
-      sources."@nodelib/fs.stat-2.0.5"
-      sources."@nodelib/fs.walk-1.2.8"
-      sources."braces-3.0.3"
       sources."detect-indent-7.0.1"
       sources."detect-newline-4.0.1"
-      sources."dir-glob-3.0.1"
-      sources."fast-glob-3.3.2"
-      sources."fastq-1.17.1"
-      sources."fill-range-7.1.1"
+      sources."fdir-6.4.3"
       sources."get-stdin-9.0.0"
-      sources."git-hooks-list-3.1.0"
-      sources."glob-parent-5.1.2"
-      sources."globby-13.2.2"
-      sources."ignore-5.3.2"
-      sources."is-extglob-2.1.1"
-      sources."is-glob-4.0.3"
-      sources."is-number-7.0.0"
+      sources."git-hooks-list-3.2.0"
       sources."is-plain-obj-4.1.0"
-      sources."merge2-1.4.1"
-      sources."micromatch-4.0.8"
-      sources."path-type-4.0.0"
-      sources."picomatch-2.3.1"
-      sources."queue-microtask-1.2.3"
-      sources."reusify-1.0.4"
-      sources."run-parallel-1.2.0"
-      sources."semver-7.6.3"
-      sources."slash-4.0.0"
+      sources."picomatch-4.0.2"
+      sources."semver-7.7.1"
       sources."sort-object-keys-1.1.3"
-      sources."to-regex-range-5.0.1"
+      sources."tinyglobby-0.2.12"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -1035,25 +875,25 @@ in
       sources."@jridgewell/resolve-uri-3.1.2"
       sources."@jridgewell/sourcemap-codec-1.5.0"
       sources."@jridgewell/trace-mapping-0.3.9"
-      sources."@swc/core-1.7.28"
+      sources."@swc/core-1.10.18"
       sources."@swc/counter-0.1.3"
-      sources."@swc/helpers-0.5.13"
-      sources."@swc/types-0.1.12"
-      sources."@swc/wasm-1.7.28"
+      sources."@swc/helpers-0.5.15"
+      sources."@swc/types-0.1.17"
+      sources."@swc/wasm-1.10.18"
       sources."@tsconfig/node10-1.0.11"
       sources."@tsconfig/node12-1.0.11"
       sources."@tsconfig/node14-1.0.3"
       sources."@tsconfig/node16-1.0.4"
-      sources."@types/node-22.6.1"
-      sources."acorn-8.12.1"
+      sources."@types/node-22.13.5"
+      sources."acorn-8.14.0"
       sources."acorn-walk-8.3.4"
       sources."arg-4.1.3"
       sources."create-require-1.1.1"
       sources."diff-4.0.2"
       sources."make-error-1.3.6"
-      sources."tslib-2.7.0"
-      sources."typescript-5.6.2"
-      sources."undici-types-6.19.8"
+      sources."tslib-2.8.1"
+      sources."typescript-5.7.3"
+      sources."undici-types-6.20.0"
       sources."v8-compile-cache-lib-3.0.1"
       sources."yn-3.1.1"
     ];

--- a/modules/packages/cli.nix
+++ b/modules/packages/cli.nix
@@ -58,7 +58,7 @@ with pkgs; lib.attrValues {
   ];
   platform =
     lib.optionals (!stdenv.isDarwin) [
-      dstat # Versatile resource statistics tool
+      dool # Python3 compatible clone of dstat
       sysstat # A collection of performance monitoring tools for Linux (such as sar, iostat and pidstat)
     ] ++ lib.optionals meta.isWsl [
       wslu # A collection of utilities for Windows 10 Linux Subsystems

--- a/modules/packages/cloud.nix
+++ b/modules/packages/cloud.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 
-with pkgs ; [
+with pkgs;
+[
   aws-mfa # Manage AWS MFA Security Credentials
   aws-vault # A vault for securely storing and accessing AWS credentials in development environments
   awscli2
@@ -8,6 +9,8 @@ with pkgs ; [
   heroku
   netlify-cli
   nodePackages.vercel
-] ++ lib.optionals (!stdenv.isDarwin) [
-  wrangler # A CLI tool designed for folks who are interested in using Cloudflare Workers
+]
+++ lib.optionals (!stdenv.isDarwin) [
+  # TODO: Avoid build failure on Linux
+  # wrangler # A CLI tool designed for folks who are interested in using Cloudflare Workers
 ]

--- a/modules/packages/langs.nix
+++ b/modules/packages/langs.nix
@@ -24,7 +24,9 @@ lib.attrValues {
       prettier
       serverless
       typescript
-      webpack-cli
+      # TODO: Cant be read $out for some reason
+      # See https://github.com/NixOS/nixpkgs/issues/380681 or https://github.com/NixOS/nixpkgs/issues/380436
+      # webpack-cli
     ]);
   js = [
     biome # Toolchain of the web

--- a/modules/packages/nix.nix
+++ b/modules/packages/nix.nix
@@ -2,7 +2,7 @@
 with pkgs; [
   alejandra
   nil
-  nixpkgs-fmt
+  nixfmt-rfc-style
   nixpkgs-lint
   nixpkgs-review
   nix-prefetch-git

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,5 +1,5 @@
 [formatter.nix]
-command = "nixpkgs-fmt"
+command = "nixfmt"
 includes = ["./**/*.nix"]
 
 [formatter.shellscript]

--- a/unix/.config/Code/User/settings.json
+++ b/unix/.config/Code/User/settings.json
@@ -161,8 +161,7 @@
   // Nix
   "[nix]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "B4dM4n.nixpkgs-fmt"
-    // "editor.defaultFormatter": "kamadorueda.alejandra"
+    "editor.defaultFormatter": "brettm12345.nixfmt-vscode"
   },
   "nix.enableLanguageServer": true,
   "nix.serverPath": "nil",

--- a/unix/Library/Application Support/Code/User/settings.json
+++ b/unix/Library/Application Support/Code/User/settings.json
@@ -161,8 +161,7 @@
   // Nix
   "[nix]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "B4dM4n.nixpkgs-fmt"
-    // "editor.defaultFormatter": "kamadorueda.alejandra"
+    "editor.defaultFormatter": "brettm12345.nixfmt-vscode"
   },
   "nix.enableLanguageServer": true,
   "nix.serverPath": "nil",

--- a/windows/AppData/Roaming/Code/User/settings.json
+++ b/windows/AppData/Roaming/Code/User/settings.json
@@ -170,8 +170,7 @@
   // Nix
   "[nix]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "B4dM4n.nixpkgs-fmt"
-    // "editor.defaultFormatter": "kamadorueda.alejandra"
+    "editor.defaultFormatter": "brettm12345.nixfmt-vscode"
   },
   "nix.enableLanguageServer": true,
   "nix.serverPath": "nil",


### PR DESCRIPTION
## Overview

- update flack.lock revision
  - set compatible Nix build user group id option
  - replace [dstat](https://github.com/dstat-real/dstat) to [dool](https://github.com/scottchiefbaker/dool)
- update npm packages revision

## Appendix

Close #193 and close #192